### PR TITLE
-fixed "Start Area Screenshot" not enabling if changing "Zoom level" …

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -73,9 +73,6 @@ local function loadDefaultsForPlayer(index)
 
 	if not storage.snip[index].jpg_quality then storage.snip[index].jpg_quality = 100 end
 	log(l.info("jpg quality is " .. storage.snip[index].jpg_quality))
-	
-	if storage.snip[index].enableScreenshotButton == nil then storage.snip[index].enableScreenshotButton = false end
-	log(l.info("enableScreenshotButton is " .. (storage.snip[index].enableScreenshotButton and "true" or "false")))
 
 
 	shooter.evaluateZoomForPlayerAndAllSurfaces(index)
@@ -268,7 +265,6 @@ function handlers.delete_area_button_click(event)
 	log(l.info("delete area button was clicked by player " .. event.player_index))
 	snip.resetArea(event.player_index)
     snip.calculateEstimates(event.player_index)
-    snip.checkIfScreenshotPossible(event.player_index)
 
 	gui.resetAreaValues(event.player_index)
 	gui.refreshEstimates(event.player_index)
@@ -451,10 +447,9 @@ end
 
 
 -- #region shortcuts handlers
-local function handleAreaChange(index)
-    snip.calculateArea(index)
+local function handleAreaChange(index, new_area)
+    snip.calculateArea(index, new_area)
     snip.calculateEstimates(index)
-    snip.checkIfScreenshotPossible(index)
 
     if storage.gui[index] then
         gui.refreshAreaValues(index)
@@ -463,28 +458,12 @@ local function handleAreaChange(index)
     end
 end
 
-local function on_left_click(event)
-    if storage.snip[event.player_index].doesSelection then
-        log(l.info("left click event fired while doing selection by player " .. event.player_index))
-        storage.snip[event.player_index].areaLeftClick = event.cursor_position
-        if game.get_player(event.player_index).surface.name ~= storage.snip[event.player_index].surface_name then
-            -- Surface has changed, new area
-            storage.snip[event.player_index].areaRightClick = nil
-        end
-	    handleAreaChange(event.player_index)
-    end
-end
-
-local function on_right_click(event)
-    if storage.snip[event.player_index].doesSelection then
-        log(l.info("right click event fired while doing selection by player " .. event.player_index))
-        storage.snip[event.player_index].areaRightClick = event.cursor_position
-        if game.get_player(event.player_index).surface.name ~= storage.snip[event.player_index].surface_name then
-   --         Surface has changed, new area
-            storage.snip[event.player_index].areaLeftClick = nil
-        end
-		handleAreaChange(event.player_index)
-    end
+function on_player_selected_area(event)
+	--game.print("on_player_selected_area: ".. serpent.block(event))
+	
+	if storage.snip[event.player_index].doesSelection then
+	    handleAreaChange(event.player_index, event.area)
+	end
 end
 
 local function on_selection_toggle(event)
@@ -585,6 +564,7 @@ script.on_event(defines.events.on_player_joined_game, on_player_joined_game)
 script.on_event(defines.events.on_player_left_game, on_player_left_game)
 script.on_event(defines.events.on_player_cursor_stack_changed, on_player_cursor_stack_changed)
 script.on_event(defines.events.on_built_entity, on_built_entity)
+script.on_event(defines.events.on_player_selected_area, on_player_selected_area)
 
 -- gui events
 script.on_event(defines.events.on_gui_click, on_gui_click)
@@ -593,8 +573,6 @@ script.on_event(defines.events.on_gui_text_changed, on_gui_text_changed)
 script.on_event(defines.events.on_gui_selection_state_changed, on_gui_selection_state_changed)
 
 -- shortcuts
-script.on_event("FAS-left-click", on_left_click)
-script.on_event("FAS-right-click", on_right_click)
 script.on_event("FAS-selection-toggle-shortcut", on_selection_toggle)
 script.on_event("FAS-delete-area-shortcut", on_delete_area)
 script.on_event("FAS-toggle-GUI", on_toggle_gui)

--- a/data.lua
+++ b/data.lua
@@ -4,16 +4,6 @@ require("prototypes.styles")
 data:extend{
     {
         type = "custom-input",
-        name = "FAS-left-click",
-        key_sequence = "mouse-button-1"
-    },
-    {
-        type = "custom-input",
-        name = "FAS-right-click",
-        key_sequence = "mouse-button-2"
-    },
-    {
-        type = "custom-input",
         name = "FAS-selection-toggle-shortcut",
         key_sequence = "SHIFT + ALT + S"
     },

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -12,9 +12,9 @@ FAS-splitting-factor-tooltip=This causes the screenshots to be split into smalle
 
 FAS-area-screenshots-label=Area Screenshots
 FAS-area-caption=Area [img=info]
-FAS-area-tooltip=Select an area by clicking two positions with Left mouse button and Right mouse button.
-FAS-area-select-button-tooltip=Select an area to screenshot.
-FAS-delete-area-button-tooltip=Delete current area selection.
+FAS-area-tooltip=Select an area with the area tool.
+FAS-area-select-button-tooltip=Select an area to screenshot.\nDefault hotkey: [SHIFT + ALT + S]
+FAS-delete-area-button-tooltip=Delete current area selection.\nDefault hotkey: [SHIFT + ALT + D]
 FAS-width-label-caption=Width
 FAS-height-label-caption=Height
 FAS-daytime-caption=Time of day [img=info]
@@ -45,15 +45,9 @@ FAS-start-area-screenshot-button-caption=Start Area Screenshot
 FAS-did-screenshot=Screenshot saved in: __1__
 
 [controls]
-FAS-left-click=Area Select Position 1
-FAS-right-click=Area Select Position 2
 FAS-delete-area-shortcut=Delete area selection
 FAS-selection-toggle-shortcut=Toggle area selection
 FAS-toggle-GUI=Toggle Screenshot GUI
-
-[controls-description]
-FAS-left-click=The key to press when selecting the first of the two positions of the area for a screenshot.
-FAS-right-click=The key to press when selecting the second of the two positions of the area for a screenshot.
 
 [mod-setting-name]
 FAS-enable-debug=Enable debug?

--- a/scripts/gui.lua
+++ b/scripts/gui.lua
@@ -1,6 +1,7 @@
 local guiBuilder = require("guibuilder")
 local l = require("logger")
 local modGui = require("mod-gui")
+local snip = require("snip")
 
 local gui = {}
 
@@ -82,8 +83,7 @@ end
 function gui.refreshStartHighResScreenshotButton(index)
     -- {1, 16384}
     if guiIsValid(index) then
-        storage.gui[index].start_area_screenshot_button.enabled =
-            storage.snip[index].enableScreenshotButton
+        storage.gui[index].start_area_screenshot_button.enabled = snip.isScreenshotPossible(index)
     end
 end
 

--- a/scripts/snip.lua
+++ b/scripts/snip.lua
@@ -6,12 +6,6 @@ function snip.resetArea(index)
     if storage.snip[index].area.width then
         storage.snip[index].area = {}
     end
-    if storage.snip[index].areaLeftClick then
-        storage.snip[index].areaLeftClick = nil
-    end
-    if storage.snip[index].areaRightClick then
-        storage.snip[index].areaRightClick = nil
-    end
     if storage.snip[index].rec then
 		storage.snip[index].rec.destroy()
         storage.snip[index].rec = nil
@@ -27,49 +21,20 @@ function snip.resetArea(index)
     end
 end
 
-function snip.calculateArea(index)
-    if storage.snip[index].areaLeftClick == nil and storage.snip[index].areaRightClick == nil then
-        log(l.warn("something went wrong when calculating selected area, aborting"))
-        return
-    end
+function snip.calculateArea(index, new_area)
+	assert(new_area)
 
-    local top
-    local left
-    local bottom
-    local right
-
-    if storage.snip[index].areaLeftClick then
-        top = storage.snip[index].areaLeftClick.y
-        left = storage.snip[index].areaLeftClick.x
-    end
-    if storage.snip[index].areaRightClick then
-        bottom = storage.snip[index].areaRightClick.y
-        right = storage.snip[index].areaRightClick.x
-    end
-
-    if not top then
-        top = bottom
-        left = right
-    elseif not bottom then
-        bottom = top
-        right = left
-    end
-
-    if left > right then
-        local temp = left
-        left = right
-        right = temp
-    end
-
-    if top > bottom then
-        local temp = bottom
-        bottom = top
-        top = temp
-    end
+    local left   = new_area.left_top.x
+    local top    = new_area.left_top.y
+    local right  = new_area.right_bottom.x
+    local bottom = new_area.right_bottom.y
+	
+	assert(right >= right)
+	assert(bottom >= top)
 
     --rounding the limits
     top = math.floor(top)
-    left = math.floor (left)
+    left = math.floor(left)
     right = math.ceil(right)
     bottom = math.ceil(bottom)
 
@@ -149,17 +114,16 @@ function snip.calculateEstimates(index)
     storage.snip[index].filesize = size
 end
 
-function snip.checkIfScreenshotPossible(index)
+function snip.isScreenshotPossible(index)
     -- {1, 16384}
     local zoom = 1 / storage.snip[index].zoomLevel
     if not storage.snip[index].area.width then
-        storage.snip[index].enableScreenshotButton = false
+        return false
     else
         local resX = math.floor((storage.snip[index].area.right - storage.snip[index].area.left) * 32 * zoom)
         local resY = math.floor((storage.snip[index].area.bottom - storage.snip[index].area.top) * 32 * zoom)
 
-        local enable = resX < 16385 and resY < 16385
-        storage.snip[index].enableScreenshotButton = enable
+        return resX < 16385 and resY < 16385
     end
 end
 


### PR DESCRIPTION
-fixed "Start Area Screenshot" not enabling if changing "Zoom level" slider bug by eliminating enableScreenshotButton
-eliminated confusing left/right are selection by using on_player_selected_area event